### PR TITLE
Backend Example HPA Fix

### DIFF
--- a/charts/backend-example/Chart.yaml
+++ b/charts/backend-example/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backend-example/templates/hpa-blue.yaml
+++ b/charts/backend-example/templates/hpa-blue.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "backend-example.fullname" . }}-blue
+  labels:
+    {{- include "backend-example.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "backend-example.fullname" . }}-blue
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/backend-example/templates/hpa-green.yaml
+++ b/charts/backend-example/templates/hpa-green.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "backend-example.fullname" . }}
+  name: {{ include "backend-example.fullname" . }}-green
   labels:
     {{- include "backend-example.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "backend-example.fullname" . }}
+    name: {{ include "backend-example.fullname" . }}-green
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/charts/backend-example/values.yaml
+++ b/charts/backend-example/values.yaml
@@ -117,8 +117,8 @@ resources: {}
 
 autoscaling:
   enabled: true
-  minReplicas: 1
-  maxReplicas: 3
+  minReplicas: 2
+  maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
Added hpa-green and hpa-blue, bumped Chart version modified the values
for autoscaling so we can be sure its working (minimum 2 replicas now)

	modified:   backend-example/Chart.yaml
	renamed:    backend-example/templates/hpa.yaml -> backend-example/templates/hpa-blue.yaml
	new file:   backend-example/templates/hpa-green.yaml
	modified:   backend-example/values.yaml