### PR TITLE
Updates to AppMesh Core.

### DIFF
--- a/charts/appmesh-core/Chart.yaml
+++ b/charts/appmesh-core/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "1.0.2"

--- a/charts/appmesh-core/templates/NOTES.txt
+++ b/charts/appmesh-core/templates/NOTES.txt
@@ -5,16 +5,16 @@
   http{{ if $.Values.appMesh.gateway.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.appMesh.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "appmesh-core.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if contains "LoadBalancer" .Values.appMesh.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "appmesh-core.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "appmesh-core.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
+  echo http://$SERVICE_IP:{{ .Values.appMesh.service.port }}
+{{- else if contains "ClusterIP" .Values.appMesh.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "appmesh-core.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"

--- a/charts/appmesh-core/templates/hpa.yaml
+++ b/charts/appmesh-core/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "appmesh-core.fullname" . }}-blue
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "appmesh-core.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "appmesh-core.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/appmesh-core/templates/service-ingress.yaml
+++ b/charts/appmesh-core/templates/service-ingress.yaml
@@ -4,12 +4,17 @@ kind: Service
 metadata:
   name: {{ .Values.appMesh.gateway.name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "appmesh-core.labels" . | indent 4 }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: {{ .Values.appMesh.gateway.lbType }}
+    {{- range $key, $value := .Values.appMesh.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.appMesh.service.type }}
+  externalTrafficPolicy: {{ .Values.appMesh.service.externalTrafficPolicy }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.appMesh.service.port }}
       targetPort: {{ .Values.appMesh.gateway.port }}
       name: {{ .Values.appMesh.gateway.proto }}
   selector:

--- a/charts/appmesh-core/values.yaml
+++ b/charts/appmesh-core/values.yaml
@@ -43,6 +43,14 @@ appMesh:
   aws:
     arn: # The ARN of an existing mesh set external to true above
     accountID: # If external provide an external accountID
+  service:
+    port: 80
+    type: LoadBalancer  # Choices: ClusterIP / NodePort / LoadBalancer / ExternalName. More info below
+    # https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    externalTrafficPolicy: Cluster  # Choices: Cluster / Local. More info below
+    # https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
 
   healthCheck:
     healthyThreshold: 2
@@ -58,14 +66,17 @@ rbac:
   # rbac.pspEnabled: `true` if PodSecurityPolicy resources should be created
   pspEnabled: false
 
-service:
-  port: 80
-
 securityGroup:
   create: false
   name: "" #appmesh-core
   groupIds: [] # A list of security group ids to map to
     # - <sg-abc123>
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 90
 
 imagePullSecrets: []
 nameOverride: ""
@@ -96,12 +107,6 @@ securityContext:
   # readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
-
-service:
-  type: ClusterIP
-  port: 80
-  portName: http
-  targetPort: http
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
1. Service-ingress Made more flexible to support hopefully private
   ingress

2. Added Support for horizontal pod autoscaling of gateway pods.

	modified:   charts/appmesh-core/Chart.yaml
	modified:   charts/appmesh-core/templates/NOTES.txt
	new file:   charts/appmesh-core/templates/hpa.yaml
	modified:   charts/appmesh-core/templates/service-ingress.yaml
	modified:   charts/appmesh-core/values.yaml