### PR TITLE
Noths-Service-HA v0.5.0

### DIFF
--- a/charts/noths-service-ha/Chart.yaml
+++ b/charts/noths-service-ha/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.1"
+appVersion: "5.0.0"

--- a/charts/noths-service-ha/templates/api-gateway-route.yaml
+++ b/charts/noths-service-ha/templates/api-gateway-route.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.appMesh.gateway.www.route.create -}}
+{{- if .Values.appMesh.gateway.api.route.create -}}
 apiVersion: appmesh.k8s.aws/v1beta2
 kind: GatewayRoute
 metadata:
-  name: {{ .Values.appMesh.gateway.www.route.name }}
-  namespace: {{ .Values.appMesh.gateway.www.route.namespace }}
+  name: {{ .Values.appMesh.gateway.api.route.name }}
+  namespace: {{ .Values.appMesh.gateway.api.route.namespace }}
 spec:
   httpRoute:
     match:
-      prefix: {{ .Values.appMesh.gateway.www.route.prefix }}
+      prefix: {{ .Values.appMesh.gateway.api.route.prefix }}
     action:
       target:
         virtualService:

--- a/charts/noths-service-ha/templates/deployment-blue.yaml
+++ b/charts/noths-service-ha/templates/deployment-blue.yaml
@@ -46,7 +46,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .template "noths-service-ha.name" . }}-blue
+        - name: {{ template "noths-service-ha.name" . }}-blue
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tagBlue | default .Chart.AppVersion }}"
@@ -55,14 +55,12 @@ spec:
             - name: http
               containerPort: {{ .Values.deployment.containerPort }}
               protocol: TCP
+          {{- if .Values.deployment.enableProbes }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/noths-service-ha/templates/deployment-green.yaml
+++ b/charts/noths-service-ha/templates/deployment-green.yaml
@@ -46,7 +46,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .template "noths-service-ha.name" . }}-green
+        - name: {{ template "noths-service-ha.name" . }}-green
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tagGreen | default .Chart.AppVersion }}"
@@ -55,14 +55,12 @@ spec:
             - name: http
               containerPort: {{ .Values.deployment.containerPort }}
               protocol: TCP
+          {{- if .Values.deployment.enableProbes }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.deployment.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
+            {{- toYaml .Values.deployment.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/noths-service-ha/templates/private-gateway-route.yaml
+++ b/charts/noths-service-ha/templates/private-gateway-route.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.appMesh.gateway.www.route.create -}}
+{{- if .Values.appMesh.gateway.private.route.create -}}
 apiVersion: appmesh.k8s.aws/v1beta2
 kind: GatewayRoute
 metadata:
-  name: {{ .Values.appMesh.gateway.www.route.name }}
-  namespace: {{ .Values.appMesh.gateway.www.route.namespace }}
+  name: {{ .Values.appMesh.gateway.private.route.name }}
+  Namespace: {{ .Values.appMesh.gateway.private.route.namespace }}
 spec:
   httpRoute:
     match:
-      prefix: {{ .Values.appMesh.gateway.www.route.prefix }}
+      prefix: {{ .Values.appMesh.gateway.private.route.prefix }}
     action:
       target:
         virtualService:

--- a/charts/noths-service-ha/templates/virtual-node-blue.yaml
+++ b/charts/noths-service-ha/templates/virtual-node-blue.yaml
@@ -20,8 +20,8 @@ spec:
   - portMapping:
       port: {{ .Values.deployment.containerPort }}
       protocol: http  
-    {{- if .Values.appMesh.backendVirtualServices }}
-    {{ toYaml .Values.appMesh.healthCheck }}
+    {{- if .Values.appMesh.node.enableHealthCheck }}
+    {{ toYaml .Values.appMesh.node.healthCheck }}
     {{- end }}
   backends:
     - virtualService:

--- a/charts/noths-service-ha/templates/virtual-node-green.yaml
+++ b/charts/noths-service-ha/templates/virtual-node-green.yaml
@@ -20,8 +20,8 @@ spec:
   - portMapping:
       port: {{ .Values.deployment.containerPort }}
       protocol: http  
-    {{- if .Values.appMesh.backendVirtualServices }}
-    {{ toYaml .Values.appMesh.healthCheck }}
+    {{- if .Values.appMesh.node.enableHealthCheck }}
+    {{ toYaml .Values.appMesh.node.healthCheck }}
     {{- end }}
   backends:
     - virtualService:

--- a/charts/noths-service-ha/templates/virtual-router.yaml
+++ b/charts/noths-service-ha/templates/virtual-router.yaml
@@ -12,12 +12,13 @@ spec:
   listeners:
     - portMapping:
         port: {{ .Values.service.port }}
-        protocol: {{ .Values.appMesh.vRouterListenerProtocol }}
+        protocol: {{ .Values.appMesh.router.listenerProtocol }}
   routes:
-    - name: {{ template "noths-service-ha.name" . }}-route
+    {{- if .Values.appMesh.gateway.www.create -}}
+    - name: {{ template "noths-service-ha.name" . }}-www-route
       httpRoute:
         match:
-          prefix: {{ .Values.appMesh.gateway.route.prefix }}
+          prefix: {{ .Values.appMesh.gateway.www.route.prefix }}
         action:
           weightedTargets:
           {{- range required "At least one target VirtualNode has to be specified" .Values.appMesh.targets }}
@@ -25,3 +26,30 @@ spec:
                 name: {{ .vNodeName }}
               weight: {{ .weight }}
           {{- end }}
+    {{- end }}
+    {{- if .Values.appMesh.gateway.api.create -}}
+    - name: {{ template "noths-service-ha.name" . }}-api-route
+      httpRoute:
+        match:
+          prefix: {{ .Values.appMesh.gateway.api.route.prefix }}
+        action:
+          weightedTargets:
+          {{- range required "At least one target VirtualNode has to be specified" .Values.appMesh.targets }}
+            - virtualNodeRef:
+                name: {{ .vNodeName }}
+              weight: {{ .weight }}
+          {{- end }}
+    {{- end }}
+    {{- if .Values.appMesh.gateway.private.create -}}
+    - name: {{ template "noths-service-ha.name" . }}-private-route
+      httpRoute:
+        match:
+          prefix: {{ .Values.appMesh.gateway.private.route.prefix }}
+        action:
+          weightedTargets:
+          {{- range required "At least one target VirtualNode has to be specified" .Values.appMesh.targets }}
+            - virtualNodeRef:
+                name: {{ .vNodeName }}
+              weight: {{ .weight }}
+          {{- end }}
+    {{- end }}

--- a/charts/noths-service-ha/values.yaml
+++ b/charts/noths-service-ha/values.yaml
@@ -21,36 +21,55 @@ deployment:
   dnsDomain: "" # e.g svc.cluster.local
   env: # Environmet variables please provide as a key / value map
   secrets: {}  # Secret Variables (pumped to kube secrets) Please provides as a key / value map
+  enableProbes: false
+  livenessProbe: {}
+  readinessProbe: {}
 
 appMesh:
   create: false
   external: false
   name: # e.g test-mesh
-  enableExternalTraffic: false
-  vRouterListenerProtocol: http
-  gatewayRouteMatchPrefix: # Supply override here, otherwise it's "/service-name"
   targets:  # Uncomment snippet below to set route(s) to your existing back-end app Virtual Node
     - vNodeName: ""
       weight: 100
   gateway:
-    name: # The name of the appmesh gateway
-    route:
-      create: true
-      port: 8088
-      prefix: "/"
+    api:
+      route:
+        name: # The name of the appmesh api gateway
+        namespace: ""
+        create: false
+        port: 8088
+        prefix: "/"
+    www:
+      route:
+        name: # The name of the appmesh www gateway
+        namespace: ""
+        create: true
+        port: 8088
+        prefix: "/"
+    private:
+      route:
+        name: # The name of the appmesh private gateway
+        namespace: ""
+        create: false
+        port: 8088
+        prefix: "/"
+  router:
+    listenerProtocol: http
+  node:
+    enableHealthCheck: false
+    healthCheck:
+      healthyThreshold: 2
+      intervalMillis: 5000
+      path: /health
+      protocol: http
+      timeoutMillis: 2000
+      unhealthyThreshold: 2
   envoy:
     image: "public.ecr.aws/appmesh/aws-appmesh-envoy:v1.19.0.0-prod"
   aws:
     arn: # The ARN of an existing mesh set external to true above
     accountID: # If external provide an external accountID
-
-  healthCheck:
-    healthyThreshold: 2
-    intervalMillis: 5000
-    path: /health 
-    protocol: http
-    timeoutMillis: 2000
-    unhealthyThreshold: 2
 
 rbac:
   # rbac.create: `true` if rbac resources should be created

--- a/charts/noths-service-std/Chart.yaml
+++ b/charts/noths-service-std/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0"
+appVersion: "5.0.0"

--- a/charts/noths-service-std/values.yaml
+++ b/charts/noths-service-std/values.yaml
@@ -59,7 +59,7 @@ appMesh:
     healthCheck:
       healthyThreshold: 2
       intervalMillis: 5000
-      path: /health 
+      path: /health
       protocol: http
       timeoutMillis: 2000
       unhealthyThreshold: 2


### PR DESCRIPTION
* added support for user configurable health checks in deployment
* added support for multiple gateway routes in both gateway routes and
  virtual router.
* Virtual node cleaned up health check

Noths-Service-Std v0.5.0
^^ same as ha, forgot to bump chart version, now done.

	modified:   noths-service-ha/Chart.yaml
	new file:   noths-service-ha/templates/api-gateway-route.yaml
	modified:   noths-service-ha/templates/deployment-blue.yaml
	modified:   noths-service-ha/templates/deployment-green.yaml
	new file:   noths-service-ha/templates/private-gateway-route.yaml
	modified:   noths-service-ha/templates/virtual-node-blue.yaml
	modified:   noths-service-ha/templates/virtual-node-green.yaml
	modified:   noths-service-ha/templates/virtual-router.yaml
	modified:   noths-service-ha/templates/www-gateway-route.yaml
	modified:   noths-service-ha/values.yaml
	modified:   noths-service-std/Chart.yaml
	modified:   noths-service-std/values.yaml